### PR TITLE
Fix incorrect arx shutdown call in the sample script

### DIFF
--- a/samples/logipy_samples.py
+++ b/samples/logipy_samples.py
@@ -67,7 +67,7 @@ logi_arx.logi_arx_add_utf8_string_as(index, 'index.html', 'text/html')
 logi_arx.logi_arx_add_utf8_string_as(css, 'style.css', 'text/css')
 logi_arx.logi_arx_set_index('index.html')
 raw_input('Press enter to shutdown SDK...')
-logi_led.logi_led_shutdown()
+logi_arx.logi_arx_shutdown()
 
 # Show a simple applet with a custom callback
 from logipy import logi_arx


### PR DESCRIPTION
There was a small mistake in the sample script (samples/logipy_samples.py) where logi_led.logi_led_shutdown() was called instead of logi_arx.logi_arx_shutdown() after the first arx example had completed which caused Python to crash.

The fix is tiny and just calls logi_arx.logi_arx_shutdown() instead of logi_led.logi_led_shutdown().
