### PR TITLE
Update logi_led.py

### DIFF
--- a/logipy/logi_led.py
+++ b/logipy/logi_led.py
@@ -216,7 +216,7 @@ LOGI_DEVICETYPE_ALL             = LOGI_DEVICETYPE_MONOCHROME | LOGI_DEVICETYPE_R
 #
 _LOGI_SHARED_SDK_LED            = ctypes.c_int(1)
 
-class SDKNotFoundException:
+class SDKNotFoundException(BaseException):
     pass
 
 def load_dll(path_dll = None):


### PR DESCRIPTION
Fixed `TypeError: catching classes that do not inherit from BaseException is not allowed` error